### PR TITLE
Fix for optional decimal length - '0.0[000]', etc

### DIFF
--- a/src/Numeral.php
+++ b/src/Numeral.php
@@ -193,7 +193,7 @@ class Numeral
 
             // Handle the case where there are more decimal places
             // than are desired.
-            if ($currentDecimalLength > $decimalPlaces) {
+            if ($currentDecimalLength >= $decimalPlaces) {
                 $roundedValue = round($number, $decimalPlaces);
                 return $this->addPaddingToNumber($roundedValue, $decimalPlaces, $optionalDigits);
             }


### PR DESCRIPTION
IDK if it is universal fix, but that worked for me. Before that optional decimal length didn't work.
