### PR TITLE
Fix deprecated implicit conversion on PHP 8.1

### DIFF
--- a/src/Numeral.php
+++ b/src/Numeral.php
@@ -717,7 +717,7 @@ class Numeral
 
 
             $totalLength = floor(log($abs) / log(10)) + 1;
-            $minimumPrecision = $totalLength % 3;
+            $minimumPrecision = (int)$totalLength % 3;
             $minimumPrecision = ($minimumPrecision === 0) ? 3 : $minimumPrecision;
 
             if ($intPrecision > 0 && $abs !== 0) {


### PR DESCRIPTION
Deprecated: Implicit conversion from float -INF to int loses precision in /app/vendor/stillat/numeral.php/src/Numeral.php on line 720